### PR TITLE
Add ItemFishedEvent

### DIFF
--- a/src/main/java/com/wdiscute/starcatcher/registry/FishProperties.java
+++ b/src/main/java/com/wdiscute/starcatcher/registry/FishProperties.java
@@ -44,6 +44,7 @@ import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.entity.item.ItemEntity;
 import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.entity.projectile.FishingHook;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.Items;
@@ -55,6 +56,8 @@ import net.minecraft.world.level.storage.loot.parameters.LootContextParamSets;
 import net.minecraft.world.level.storage.loot.parameters.LootContextParams;
 import net.minecraft.world.phys.Vec3;
 import net.neoforged.fml.ModList;
+import net.neoforged.neoforge.common.NeoForge;
+import net.neoforged.neoforge.event.entity.player.ItemFishedEvent;
 import net.neoforged.neoforge.network.codec.NeoForgeStreamCodecs;
 import org.jetbrains.annotations.NotNull;
 
@@ -2081,6 +2084,17 @@ public record FishProperties(
                 if (completedTreasure || fbe.modifiers.stream().anyMatch(acm -> acm.forceAwardTreasure(fbe, time, completedTreasure, perfectCatch, hits)))
                 {
                     items.add(fp.loadTreasure(player).catchInfo.treasureIs);
+                }
+
+                //fire ItemFishedEvent for mod compat (e.g. PMMO). Throwaway FishingHook only exists to satisfy the event constructor.
+                if (!items.isEmpty())
+                {
+                    FishingHook fakeHook = new FishingHook(player, level, 0, 0);
+                    fakeHook.setPos(fbe.position());
+                    ItemFishedEvent event = new ItemFishedEvent(items, 0, fakeHook);
+                    NeoForge.EVENT_BUS.post(event);
+                    if (event.isCanceled()) items.clear();
+                    fakeHook.discard();
                 }
 
                 //spawn items from list


### PR DESCRIPTION
I added ItemFishedEvent to provide the same behavior that vanilla does. This is cancellable and when cancelled just removes the fish look from the reward, which is the same thing vanilla does as well. The event requires a FishingHook object, which your mod doesn't have, but it doesn't really matter, creating a fake one and discarding it after is just fine. 99%+ of ItemFishedEvent consumers don't use the FishingHook, and if they do then they'll have to figure something else out for this mod.

This gives modders or modpack makers a hook to interact more with your mod and integrate it into others. Also mods like Project MMO only add XP for fishing from consuming this event.

Please let me know if you'd like anything about it changed! I can always do a mixin to do a custom compat for my mod but this would be much cleaner!

Thanks!