### PR TITLE
Fix tournament stand removal disconnects

### DIFF
--- a/src/main/java/com/wdiscute/starcatcher/blocks/stand/StandBlock.java
+++ b/src/main/java/com/wdiscute/starcatcher/blocks/stand/StandBlock.java
@@ -116,9 +116,12 @@ public class StandBlock extends AbstractMultiBlock implements IPreviewableMultib
     @Override
     protected void onRemove(BlockState state, Level level, BlockPos pos, BlockState newState, boolean movedByPiston)
     {
-        //before super since super removed BE
-        BlockPos center = IMultiBlock.getCenter(level, pos);
-        if (level.getBlockEntity(center) instanceof StandBlockEntity sbe && !level.isClientSide && sbe.tournament != null)
+        // Only the center owns the tournament. During survival destruction the multiblock
+        // removes several parts in sequence, so forwarding every part here cancels and
+        // broadcasts the same tournament more than once.
+        if (!state.is(newState.getBlock()) && state.getValue(CENTER)
+                && level.getBlockEntity(pos) instanceof StandBlockEntity sbe
+                && !level.isClientSide && sbe.tournament != null)
         {
             TournamentHandler.cancelTournament(level, sbe.tournament);
         }

--- a/src/main/java/com/wdiscute/starcatcher/data/network/tournament/CBFinishedTournamentsListPayload.java
+++ b/src/main/java/com/wdiscute/starcatcher/data/network/tournament/CBFinishedTournamentsListPayload.java
@@ -14,6 +14,12 @@ import java.util.List;
 
 public record CBFinishedTournamentsListPayload(List<Tournament> list) implements CustomPacketPayload
 {
+    public CBFinishedTournamentsListPayload
+    {
+        // Encoding happens asynchronously. Keep a stable snapshot instead of exposing
+        // TournamentHandler's mutable list to Netty while another tournament finishes.
+        list = List.copyOf(list);
+    }
 
     public static final Type<CBFinishedTournamentsListPayload> TYPE = new Type<>(Starcatcher.rl("cb_finished_tournaments_list"));
 

--- a/src/main/java/com/wdiscute/starcatcher/tournament/TournamentHandler.java
+++ b/src/main/java/com/wdiscute/starcatcher/tournament/TournamentHandler.java
@@ -71,6 +71,10 @@ public class TournamentHandler
 
     public static void cancelTournament(Level level, Tournament tournament)
     {
+        // Multiblock removal can reach this method through more than one block update.
+        // A finished tournament has already been removed, recorded, and broadcast.
+        if (tournament == null || tournament.status == Tournament.Status.FINISHED) return;
+
         for (var entry : tournament.playerScores)
         {
             ServerPlayer player = level.getServer().getPlayerList().getPlayer(entry.uuid);


### PR DESCRIPTION
## Summary

Fixes players being disconnected when a tournament stand is broken in survival mode while another player has its menu open.

## Reproduction

1. Place a tournament stand.
2. Have one player open the stand menu.
3. Have another player break the stand in survival mode.
4. Some connected players are disconnected with:

`Internal Exception: io.netty.handler.codec.EncoderException: Failed to encode packet 'clientbound/minecraft:custom_payload'`

Breaking the stand in creative mode does not trigger the disconnect.

## Root cause

Survival-mode destruction removes the multiblock parts in sequence. Each removed part could cancel the same tournament and broadcast the finished-tournament list again.

The payload also retained a reference to the mutable tournament list, allowing it to change while the packet was being encoded.

## Changes

- Cancel the tournament only when the center block is actually removed.
- Ignore repeated cancellation of an already finished tournament.
- Copy the finished-tournament list when constructing the network payload.

## Testing

- Manually reproduced the multiplayer scenario and retested it after the change. Breaking the stand in survival while another player kept the menu open no longer disconnected players.
- The changed sources compile successfully.
- The full target-branch build is currently blocked by pre-existing compilation errors in `StarcatcherJeiSmithingRecipe.java`, unrelated to this change.
