### PR TITLE
[1.20.1] Unify ResourceLocation -> U#rl, bump forge min version and fix invalid/unused mods.toml fields

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -10,8 +10,8 @@ mc_version=1.20.1
 
 minecraft_version=1.20.1
 minecraft_version_range=[1.20.1,1.21)
-forge_version=47.4.0
-forge_version_range=[47.3.10,)
+forge_version=47.4.20
+forge_version_range=[47.4.20,)
 loader_version_range=[47,)
 
 parchment_mappings_version=2023.09.03

--- a/src/main/java/com/wdiscute/starcatcher/Starcatcher.java
+++ b/src/main/java/com/wdiscute/starcatcher/Starcatcher.java
@@ -89,7 +89,7 @@ public class Starcatcher
 
     public static ResourceLocation rl(String s)
     {
-        return new ResourceLocation(Starcatcher.MOD_ID, s);
+        return U.rl(Starcatcher.MOD_ID, s);
     }
 
     //shitty fix for double toast because its caused by nikdos payload sender thingy
@@ -115,10 +115,9 @@ public class Starcatcher
     }
 
 
-    public Starcatcher()
+    public Starcatcher(FMLJavaModLoadingContext ctx)
     {
-        IEventBus modEventBus = FMLJavaModLoadingContext.get().getModEventBus();
-        ModLoadingContext modContainer = ModLoadingContext.get();
+        IEventBus modEventBus = ctx.getModEventBus();
 
         SCCreativeModeTabs.register(modEventBus);
 
@@ -141,8 +140,8 @@ public class Starcatcher
         SCProcessors.register(modEventBus);
         SCLootModifiers.register(modEventBus);
 
-        modContainer.registerConfig(ModConfig.Type.CLIENT, SCConfig.SPEC);
-        modContainer.registerConfig(ModConfig.Type.SERVER, SCConfig.SPEC_SERVER);
+        ctx.registerConfig(ModConfig.Type.CLIENT, SCConfig.SPEC);
+        ctx.registerConfig(ModConfig.Type.SERVER, SCConfig.SPEC_SERVER);
 
         DistExecutor.safeRunWhenOn(Dist.CLIENT,
                 () -> Client::init);

--- a/src/main/java/com/wdiscute/starcatcher/U.java
+++ b/src/main/java/com/wdiscute/starcatcher/U.java
@@ -182,12 +182,12 @@ public class U
 
     public static ResourceLocation rl(String ns, String path)
     {
-        return new ResourceLocation(ns, path);
+        return ResourceLocation.fromNamespaceAndPath(ns, path);
     }
 
     public static ResourceLocation rl(String path)
     {
-        return new ResourceLocation("minecraft", path);
+        return ResourceLocation.withDefaultNamespace(path);
     }
 
     public static Holder<Item> holderItem(String ns, String path)

--- a/src/main/java/com/wdiscute/starcatcher/datagen/DGSCItemsTagsProvider.java
+++ b/src/main/java/com/wdiscute/starcatcher/datagen/DGSCItemsTagsProvider.java
@@ -21,6 +21,7 @@ import org.jetbrains.annotations.Nullable;
 
 import java.util.concurrent.CompletableFuture;
 
+import static com.wdiscute.starcatcher.U.rl;
 import static com.wdiscute.starcatcher.registry.SCItems.*;
 import static com.wdiscute.starcatcher.blocks.SCBlocks.*;
 
@@ -211,11 +212,5 @@ public class DGSCItemsTagsProvider extends ItemTagsProvider
                 .add(TACKLE_BOX_WHITE.asItem())
         ;
 
-    }
-
-
-    public static ResourceLocation rl(String ns, String path)
-    {
-        return new ResourceLocation(ns, path);
     }
 }

--- a/src/main/java/com/wdiscute/starcatcher/recipe/FishingRodSkinSmithingRecipeBuilder.java
+++ b/src/main/java/com/wdiscute/starcatcher/recipe/FishingRodSkinSmithingRecipeBuilder.java
@@ -3,6 +3,7 @@ package com.wdiscute.starcatcher.recipe;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.mojang.serialization.JsonOps;
+import com.wdiscute.starcatcher.U;
 import com.wdiscute.starcatcher.registry.SCRecipes;
 import net.minecraft.advancements.Advancement;
 import net.minecraft.advancements.AdvancementRewards;
@@ -61,7 +62,7 @@ public class FishingRodSkinSmithingRecipeBuilder
     }
 
     public void save(Consumer<FinishedRecipe> recipeConsumer, String location) {
-        this.save(recipeConsumer, new ResourceLocation(location));
+        this.save(recipeConsumer, U.rl(location));
     }
 
     public void save(Consumer<FinishedRecipe> recipeConsumer, ResourceLocation location) {

--- a/src/main/java/com/wdiscute/starcatcher/recipe/TackleSkinSmithingRecipeBuilder.java
+++ b/src/main/java/com/wdiscute/starcatcher/recipe/TackleSkinSmithingRecipeBuilder.java
@@ -1,6 +1,7 @@
 package com.wdiscute.starcatcher.recipe;
 
 import com.google.gson.JsonObject;
+import com.wdiscute.starcatcher.U;
 import com.wdiscute.starcatcher.registry.SCRecipes;
 import net.minecraft.advancements.Advancement;
 import net.minecraft.advancements.AdvancementRewards;
@@ -52,7 +53,7 @@ public class TackleSkinSmithingRecipeBuilder
 
 
     public void save(Consumer<FinishedRecipe> recipeConsumer, String location) {
-        this.save(recipeConsumer, new ResourceLocation(location));
+        this.save(recipeConsumer, U.rl(location));
     }
 
     public void save(Consumer<FinishedRecipe> recipeConsumer, ResourceLocation location) {

--- a/src/main/java/com/wdiscute/starcatcher/registry/FishProperties.java
+++ b/src/main/java/com/wdiscute/starcatcher/registry/FishProperties.java
@@ -67,6 +67,8 @@ import java.nio.charset.MalformedInputException;
 import java.util.*;
 import java.util.function.Supplier;
 
+import static com.wdiscute.starcatcher.U.rl;
+
 //      <><|    <- fish
 public record FishProperties(
         CatchInfo catchInfo,
@@ -1950,7 +1952,7 @@ public record FishProperties(
                 {
                     String biomeString = biomeHolder.getRegisteredName();
 
-                    rls.add(new ResourceLocation(biomeString));
+                    rls.add(rl(biomeString));
                 }
             }
         }

--- a/src/main/java/com/wdiscute/starcatcher/registry/fishrestrictions/FluidRestriction.java
+++ b/src/main/java/com/wdiscute/starcatcher/registry/fishrestrictions/FluidRestriction.java
@@ -128,9 +128,9 @@ public class FluidRestriction extends AbstractFishRestriction
         return fluid;
     }
 
-    public static final FluidRestriction LAVA = new FluidRestriction(new ResourceLocation(ResourceLocation.DEFAULT_NAMESPACE, "lava"), "");
-    public static final FluidRestriction WATER = new FluidRestriction(new ResourceLocation(ResourceLocation.DEFAULT_NAMESPACE,"water"), "");
-    public static final FluidRestriction VOID = new FluidRestriction(new ResourceLocation(ResourceLocation.DEFAULT_NAMESPACE,"empty"), "");
+    public static final FluidRestriction LAVA = new FluidRestriction(U.rl("lava"), "");
+    public static final FluidRestriction WATER = new FluidRestriction(U.rl("water"), "");
+    public static final FluidRestriction VOID = new FluidRestriction(U.rl("empty"), "");
     public static final FluidRestriction ACID = new FluidRestriction(U.rl("alexscaves", "acid"), "");
     public static final FluidRestriction PURPLE_SODA = new FluidRestriction(U.rl("alexscaves", "purple_soda"), "");
 }

--- a/src/main/templates/META-INF/mods.toml
+++ b/src/main/templates/META-INF/mods.toml
@@ -33,11 +33,7 @@ Thank you to all the translators who contribuited their time to make the mod acc
 Thank you everyone who stopped by my streams as I developed the mod and followed along the journey ♥
 '''
 
-[[mixins]]
-config="starcatcher.mixins.json"
-
-[[accessTransformers]]
-file="META-INF/accesstransformer.cfg"
+accessTransformers = ["META-INF/accesstransformer.cfg"]
 
 [[dependencies.starcatcher]] #optional
     modId="forge" #mandatory


### PR DESCRIPTION
`[[mixins]]` and `[[accessTransformers]]` are not valid syntax in forge's mods.toml. In 47.4.20 I backported support for multiple, arbitrary access transformer files, but the table format isn't how we do it. This PR removes unused toml fields (mixins is not used) and adjusts the AT to actually be what forge uses now. Also the randomly not using the rl utility functions in `U` bothered me so I changed all of them to go through it instead. Also shifted to non-deprecated stuff.

I do have one additional commit that I didn't push which entirely removes `@OnlyIn` in favor of doing classloading correctly but it felt out of scope. I can make a separate PR for it if you want/care.